### PR TITLE
Add vendors: A10 and Checkpoint Gateway

### DIFF
--- a/collection_helper.py
+++ b/collection_helper.py
@@ -7,7 +7,12 @@ import logging
 import yaml
 from netmiko import ConnectHandler, NetmikoTimeoutException
 from enum import Enum
+from ttp import ttp
 
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+A10_PARTITION_TTP_TEMPLATE = f"{SCRIPT_DIR}/ttp_templates/acos_show_partition.ttp"
+A10_VERSION_TTP_TEMPLATE = f"{SCRIPT_DIR}/ttp_templates/acos_show_version.ttp"
 
 class CollectionStatus(Enum):
     PASS = 1
@@ -16,12 +21,14 @@ class CollectionStatus(Enum):
 
 AnsibleOsToNetmikoOs = {
     "arista.eos.eos": "arista_eos",
+    "a10": "a10",
+    "check_point.gaia.checkpoint": "checkpoint_gaia",
     "cisco.asa.asa": "cisco_asa",
     "cisco.iosxr.iosxr": "cisco_xr",
     "cisco.nxos.nxos": "cisco_nxos",
     "cisco.ios.ios": "cisco_ios",
-    "juniper.junos.junos": "juniper_junos",
     "cumulus": "linux",
+    "juniper.junos.junos": "juniper_junos",
 }
 
 
@@ -48,6 +55,7 @@ class RetryingNetConnect(object):
         except Exception:
             self._logger.exception(f"Connection to {self._device_name} failed")
             raise Exception
+        self._base_prompt = self._net_connect.base_prompt
         self._logger.info(f"Netmiko prompt: {self._net_connect.base_prompt}")
 
     def run_command(self, cmd: str, cmd_timer: int, pattern=None):
@@ -129,7 +137,7 @@ def get_inventory(inventory_file: Text) -> Dict:
     return inventory['all']['children']
 
 
-def write_output_to_file(device_name: Text, output_path: Text, cmd: Text, cmd_output: Text):
+def write_output_to_file(device_name: Text, output_path: Text, cmd: Text, cmd_output: Text, prepend_text=None):
     """
     Save show commands output to it's file
     """
@@ -138,4 +146,77 @@ def write_output_to_file(device_name: Text, output_path: Text, cmd: Text, cmd_ou
 
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
     with open(file_path, "w") as f:
+        if prepend_text is not None:
+            f.write(prepend_text)
+            f.write("\n")
         f.write(cmd_output)
+
+def a10_parse_version(input: Text) -> str:
+
+    template = A10_VERSION_TTP_TEMPLATE
+
+    parser = ttp()
+    # Note:
+    #   - must add macros first, then vars and then you can add the template
+    #   - if you add templates individually, you will get multiple entries in
+    #       parser.result(). That is why it is easier to concatenate the
+    #       individual template files and then just add them as a single template
+    #       this way you get a results object for the entire input
+    #       as opposed to one object per template file
+    #
+    # to get additional debug information from ttp
+    # import logging
+    # logging.basicConfig(level=logging.DEBUG)
+    #
+
+    if template is None:
+        return []
+
+    parser.add_template(template)
+    parser.add_input(input)
+    parser.parse()
+    res = parser.result()[0][0]
+
+    if len(res) == 0:
+        return "unknown"
+
+    version = res[0].get('acos_version', None)
+    if version is None:
+        return "unknown"
+    elif re.match("^2\..*$", version):
+        return "v2"
+    else:
+        return "v4p"
+
+
+def a10_parse_partition(input: Text) -> List:
+
+    template = A10_PARTITION_TTP_TEMPLATE
+
+    parser = ttp()
+    # Note:
+    #   - must add macros first, then vars and then you can add the template
+    #   - if you add templates individually, you will get multiple entries in
+    #       parser.result(). That is why it is easier to concatenate the
+    #       individual template files and then just add them as a single template
+    #       this way you get a results object for the entire input
+    #       as opposed to one object per template file
+    #
+    # to get additional debug information from ttp
+    # import logging
+    # logging.basicConfig(level=logging.DEBUG)
+    #
+
+    if template is None:
+        return []
+
+    parser.add_template(template)
+    parser.add_input(input)
+    parser.parse()
+    res = parser.result()[0][0]
+    if len(res) == 0:
+        return []
+    else:
+        return res[0].get('partitions', [])
+
+

--- a/collection_helper.py
+++ b/collection_helper.py
@@ -2,7 +2,7 @@ import os
 import socket
 import sys
 from time import sleep
-from typing import Text, Dict
+from typing import Text, Dict, List
 import logging
 import yaml
 from netmiko import ConnectHandler, NetmikoTimeoutException
@@ -21,7 +21,7 @@ class CollectionStatus(Enum):
 
 AnsibleOsToNetmikoOs = {
     "arista.eos.eos": "arista_eos",
-    "a10": "a10",
+    "acos": "a10",
     "check_point.gaia.checkpoint": "checkpoint_gaia",
     "cisco.asa.asa": "cisco_asa",
     "cisco.iosxr.iosxr": "cisco_xr",

--- a/config_collector.py
+++ b/config_collector.py
@@ -118,7 +118,7 @@ def get_config_cumulus(device_session: dict, device_name: str, device_command: s
         status['message'] = f"Config retrieval failed. Exception {e}"
         return status
 
-    write_output_to_file(device_name, output_path, "cumulus_concatenated", output)
+    write_output_to_file(device_name, output_path, "cumulus_concatenated.txt", output)
 
     logger.info(f"Completed configuration collection for {device_name}")
     status['status'] = CollectionStatus.PASS
@@ -201,7 +201,7 @@ def get_config_a10(
                 return status
 
         logger.debug(f"Command output: {output}")
-        write_output_to_file(device_name, output_path, device_command, output, "!BATFISH_FORMAT: a10_acos")
+        write_output_to_file(device_name, output_path, cmd, output, "!BATFISH_FORMAT: a10_acos")
 
     logger.info(f"Completed configuration collection for {device_name}")
     status['status'] = CollectionStatus.PASS
@@ -255,7 +255,7 @@ def get_config_checkpoint(device_session: dict, device_name: str, device_command
     try:
         # Get the running config on the device
         logger.info(f"Running {device_command} on {device_name}")
-        output = net_connect.run_command(device_command, cmd_timer)
+        output = net_connect.run_command(device_command, cmd_timer, pattern=prompt_pattern)
         write_output_to_file(device_name, output_path, device_command, output, "#BATFISH_FORMAT: check_point_gateway")
 
     except Exception as e:

--- a/example_inventory.yml
+++ b/example_inventory.yml
@@ -36,3 +36,13 @@ all:
         ansible_network_os: juniper.junos.junos
       hosts:
         junos01: null
+    checkpointgaia:
+      vars:
+        ansible_network_os: check_point.gaia.checkpoint
+      hosts:
+        cpgw01: null
+    a10:
+      vars:
+        ansible_network_os: acos
+      hosts:
+        acos01: null

--- a/ttp_templates/acos_show_partition.ttp
+++ b/ttp_templates/acos_show_partition.ttp
@@ -1,0 +1,22 @@
+# ACOS V4, V5
+<group>
+Total Number of active partitions: {{ total | DIGIT }}
+Partition Name   Id     L3V/SP     Parent L3V           App Type   Admin Count {{ ignore }}
+------------------------------------------------------------------------------ {{ ignore }}
+<group name="partitions*" method="table">
+{{ partition_name | WORD }} {{ id | DIGIT }} {{ type | WORD }} {{ parent_L3V | WORD }} {{ app_type | WORD }} {{ admin_count | DIGIT }}
+</group>
+</group>
+# ACOS V2
+<group>
+Total Number of partitions configured:  {{ total | DIGIT }}
+Max L3V partitions allowed:             {{ max_l3v_allowed | DIGIT }}
+Max RBA partitions allowed:             {{ max_rba_allowed | DIGIT }}
+Total partitions allowed:               {{ total_partitions_allowed | DIGIT }}
+Partition Name   L3V  Index  Max. Aflex  Admin Count {{ ignore }}
+---------------------------------------------------- {{ ignore }}
+<group name="partitions*" method="table">
+{{ partition_name | WORD }} {{ l3v | WORD }} {{ index | DIGIT }} {{ max_aflex | DIGIT }} {{ admin_count | DIGIT }}
+{{ partition_name | WORD }} {{ l3v | WORD }} {{ index | DIGIT }}  * {{ max_aflex | DIGIT }} {{ admin_count | DIGIT }}
+</group>
+</group>

--- a/ttp_templates/acos_show_version.ttp
+++ b/ttp_templates/acos_show_version.ttp
@@ -1,0 +1,16 @@
+# ACOS V2
+<group>
+      64-bit Advanced Core OS (ACOS) version {{ acos_version }}, build {{ build | ORPHRASE }}
+      Serial Number: {{ serial_number }}
+      Firmware version: {{ firmware_version }}
+      aFleX version: {{ aflex_version }}
+      aXAPI version: {{ axapi_version }}
+</group>
+# ACOS V4, V5
+<group>
+          64-bit Advanced Core OS (ACOS) version {{ acos_version }}, build {{ build | ORPHRASE }}
+          Serial Number: {{ serial_number }}
+          Firmware version: {{ firmware_version }}
+          aFleX version: {{ aflex_version }}
+          aXAPI version: {{ axapi_version }}
+</group>


### PR DESCRIPTION
Add collection support for A10 and Checkpoint Gateway devices.

A10 collection handles the differences between OS version 2.x and 4.x. If the version is not 2.x or 4.x a default config without partition information will be collected. This command is version agnostic, but doesn't provide everything Batfish needs. Once we have access to other versions, we can update the logic to account for them as well.