### PR TITLE
Collect user provided list of show commands

### DIFF
--- a/collection_helper.py
+++ b/collection_helper.py
@@ -100,6 +100,7 @@ class RetryingNetConnect(object):
                     return _output
         except Exception:
             self._logger.exception(f"Command {cmd} to {self._device_name} failed")
+            #todo: determine if we should return None instead of the pass statement
             pass
         else:
             self._logger.debug(f"Output of {cmd} to {self._device_name}: {_output}")
@@ -163,6 +164,7 @@ def get_show_commands(commands_file: Text) -> Dict:
         raise Exception(f"{commands} is not properly formatted")
 
     return commands['all']
+
 
 def write_output_to_file(device_name: Text, output_path: Text, cmd: Text, cmd_output: Text, prepend_text=None):
     """
@@ -314,7 +316,7 @@ def parse_genie(device_name, cli_output, command=None, os=None, logger=None):
             return parsed_output
         except Exception as e:
             logger.error(
-                "genie_parse: {0} - Failed to parse command output.".format(e)
+                f"genie_parse: Failed to parse command {cmd} output. {str(e)}"
             )
         # what is returned if the try fails?
         # shouldn't there be a default value returned that you can check for?

--- a/collection_helper.py
+++ b/collection_helper.py
@@ -324,6 +324,10 @@ def parse_genie(device_name, cli_output, command=None, os=None, logger=None):
     # Try to parse the output
     # If OS is IOS, ansible could have passed in IOS, but the Genie device-type is actually IOS-XE,
     # so we will try to parse both.
+
+    if cli_output is None:
+        logger.error(f"No CLI output for {command} on {device_name}")
+        return None
     if os == "ios":
         try:
             return _parse(device_name, cli_output, command, "ios", logger)

--- a/collection_helper.py
+++ b/collection_helper.py
@@ -155,6 +155,15 @@ def get_inventory(inventory_file: Text) -> Dict:
     return inventory['all']['children']
 
 
+def get_show_commands(commands_file: Text) -> Dict:
+    with open(commands_file) as f:
+        commands = yaml.safe_load(f)
+
+    if commands.get("all") is None:
+        raise Exception(f"{commands} is not properly formatted")
+
+    return commands['all']
+
 def write_output_to_file(device_name: Text, output_path: Text, cmd: Text, cmd_output: Text, prepend_text=None):
     """
     Save show commands output to it's file

--- a/config_collector.py
+++ b/config_collector.py
@@ -169,7 +169,7 @@ def get_config_a10(
         output = net_connect.run_command(cmd, cmd_timer, pattern=prompt_pattern)
     except Exception as e:
         logger.exception(f"Failed to get output of {cmd}, going to sleep 10 minutes and retry")
-        sleep(600)
+        time.sleep(600)
         # reconnect to the device and run the command again
         try:
             net_connect = RetryingNetConnect(device_name, device_session, device_name)

--- a/show_commands.yml
+++ b/show_commands.yml
@@ -84,9 +84,9 @@ all:
     bgp_v4:
       global:
         neighbors:
-          - show bgp all neighbors # no genie parser
+          - show bgp all neighbors
         summary:
-          - show bgp all summary  # no genie parser
+          - show bgp all summary
         rib:
           - show bgp ipv4 unicast
         neighbor_ribs:

--- a/show_commands.yml
+++ b/show_commands.yml
@@ -46,6 +46,8 @@ all:
         - show route vrf all
     bgp_v4:
       global:
+        summary:
+          - show bgp all all summary
         neighbors:
           - show bgp all all neighbors
         rib:
@@ -81,8 +83,10 @@ all:
         - show ip route vrf all
     bgp_v4:
       global:
+        neighbors:
+          - show bgp all neighbors # no genie parser
         summary:
-          - show bgp vrf all all summary
+          - show bgp all summary  # no genie parser
         rib:
           - show bgp ipv4 unicast
         neighbor_ribs:
@@ -90,6 +94,10 @@ all:
           - show ip bgp neighbors _neigh_ received-routes
           - show ip bgp neighbors _neigh_ advertised-routes
       vrf:
+        neighbors:
+          - show bgp vrf all all neighbors
+        summary:
+          - show bgp vrf all all summary
         rib:
           - show bgp vrf all ipv4 unicast
         neighbor_ribs:
@@ -138,6 +146,6 @@ all:
         - show ip bgp summary
         - show ip bgp neigbhors
         - show ip bgp
-    partition:
-      slb:
-        - show slb virtual-server bind
+#    partition:   # this command requires parsing the partition output and is not currently handled
+#      slb:
+#        - show slb virtual-server bind

--- a/show_commands.yml
+++ b/show_commands.yml
@@ -1,0 +1,143 @@
+all:
+  aristaeos:
+    topology:
+      - show lldp neighbors detail
+      - show cdp neighbors detail
+    version:
+      - show version
+    interface:
+      - show interface
+    routes_v4:
+      global:
+        - show ip route
+  ciscoios:
+    topology:
+      - show lldp neighbors detail
+      - show cdp neighbors detail
+    version:
+      - show version
+    interface:
+      - show interface
+      - show snmp mib ifmib ifindex
+    ospf_v2:
+      - show ip ospf neighbor
+    routes_v4:
+      global:
+        - show ip route
+  ciscoiosxr:
+    topology:
+      - show lldp neighbors detail
+      - show cdp neighbors detail
+    version:
+      - show version
+    interface:
+      - show interfaces
+      - show snmp interface
+    ospf_v2:
+      - show ospf
+      - show ospf vrf all
+      - show ospf neighbor
+    routes_v4:
+      global:
+        - show route summary
+        - show route summary
+      vrf:
+        - show route vrf all summary
+        - show route vrf all
+    bgp_v4:
+      global:
+        neighbors:
+          - show bgp all all neighbors
+        rib:
+          - show bgp ipv4 unicast
+          - show bgp vpnv4 unicast
+        neighbor_ribs:
+          - show bgp ipv4 all neighbors _neigh_ advertised-routes
+          - show bgp ipv4 all neighbors _neigh_ routes
+          - show bgp ipv4 all neighbors _neigh_ received routes
+      vrf:
+        neighbors:
+          - show bgp vrf all neighbors
+        rib:
+          - show bgp vrf all
+        neighbor_ribs:
+          - show bgp vrf _vrf_ ipv4 unicast neighbors _neigh_ advertised-routes
+          - show bgp vrf _vrf_ ipv4 unicast neighbors _neigh_ routes
+          - show bgp vrf _vrf_ ipv4 unicast neighbors _neigh_ received routes
+  cisconxos:
+    topology:
+      - show lldp neighbors detail
+      - show cdp neighbors detail
+    version:
+      - show version
+    interface:
+      - show interface
+      - show interface snmp-ifindex
+      - show ip interface brief vrf all
+    ospf_v2:
+      - show ip ospf neighbor
+    routes_v4:
+      global:
+        - show ip route vrf all
+    bgp_v4:
+      global:
+        summary:
+          - show bgp vrf all all summary
+        rib:
+          - show bgp ipv4 unicast
+        neighbor_ribs:
+          - show ip bgp neighbors _neigh_ routes
+          - show ip bgp neighbors _neigh_ received-routes
+          - show ip bgp neighbors _neigh_ advertised-routes
+      vrf:
+        rib:
+          - show bgp vrf all ipv4 unicast
+        neighbor_ribs:
+          - show ip bgp vrf _vrf_ neighbors _neigh_ routes
+          - show ip bgp vrf _vrf_ neighbors _neigh_ received-routes
+          - show ip bgp vrf _vrf_ neighbors _neigh_ advertised-routes
+  checkpointgaia:
+    topology:
+      - show lldp neighbors detail
+    version:
+      - show version all
+    interface:
+      - show interfaces all
+      - show bonding groups
+    system:
+      - cphaprob -a if
+      - cphaprob role
+      - cphaprob state
+      - show cluster members interfaces all
+    routes_v4:
+      global:
+        - show route all
+    bgp_v4:
+      global:
+        - show route bgp detailed
+        - show bgp peers detailed
+  a10:
+    topology:
+      - show lldp neighbors detail
+    version:
+      - show version
+    interface:
+      - show interfaces
+    system:
+      - show partition
+    slb:
+      - show slb virtual-server all-partitions
+      - show slb virtual-server bind
+    routes_v4:
+      global:
+        - show ip route database
+        - show ip route all
+        - show ip route acos
+    bgp_v4:
+      global:
+        - show ip bgp summary
+        - show ip bgp neigbhors
+        - show ip bgp
+    partition:
+      slb:
+        - show slb virtual-server bind

--- a/show_data_collector.py
+++ b/show_data_collector.py
@@ -278,7 +278,7 @@ def get_xr_data(device_session: dict, device_name: str, output_path: str, cmd_di
                 else:
                     logger.error(f"Unknown {scope} with commands {scope_cmds} under bgp_v4 command dict")
         # handle global and vrf specific IPv4 route commands
-        if cmd_group == "routes_v4":
+        elif cmd_group == "routes_v4":
             cmd_timer = 1200  # set the RIB command timeout to 20 minutes
             cmd_list = []
             for scope, cmds in cmd_dict['routes_v4'].items():

--- a/show_data_collector.py
+++ b/show_data_collector.py
@@ -16,7 +16,6 @@ def get_nxos_data(device_session: dict, device_name: str, output_path: str, cmd_
     """
     Default config collector. Works for Cisco and Juniper devices.
     """
-    cmd_timer = 1200
     device_os = "nxos"  # used for cisco genie parsers
     start_time = time.time()
     logger.info(f"Trying to connect to {device_name} at {start_time}")
@@ -40,22 +39,16 @@ def get_nxos_data(device_session: dict, device_name: str, output_path: str, cmd_
 
     logger.info(f"Running show commands for {device_name} at {time.time()}")
 
-
-    # todo: need to handle scenarios in which command is invalid and router returns an error like:
-    # DEVICE01# show ip ospf neighbor
-    #                 ^
-    # % Invalid command at '^' marker.
-    #
-    # a local patch for this issue is required to handle this
-    # https://github.com/ktbyers/netmiko/issues/2682
-
     for cmd_group in cmd_dict.keys():
+        cmd_timer = 120     # set the general command timeout to 2 minutes
 
         if cmd_group in ["bgp_v4"]:
             # todo: handle bgp rib collection
+            cmd_timer = 1200  # set the BGP RIB command timeout to 20 minutes
             continue
         # handle global and vrf specific IPv4 route commands
         if cmd_group == "routes_v4":
+            cmd_timer = 1200  # set the RIB command timeout to 20 minutes
             cmd_list = []
             for scope, cmds in cmd_dict['routes_v4'].items():
                 cmd_list.extend(cmds)
@@ -104,7 +97,6 @@ def get_xr_data(device_session: dict, device_name: str, output_path: str, cmd_di
     """
     Default config collector. Works for Cisco and Juniper devices.
     """
-    cmd_timer = 1200
     device_os = "iosxr"  # used for cisco genie parsers
     start_time = time.time()
     logger.info(f"Trying to connect to {device_name} at {start_time}")
@@ -130,11 +122,16 @@ def get_xr_data(device_session: dict, device_name: str, output_path: str, cmd_di
     logger.info(f"Running show commands for {device_name} at {time.time()}")
 
     for cmd_group in cmd_dict.keys():
+        cmd_timer = 120     # set the general command timeout to 2 minutes
+
         if cmd_group in ["bgp_v4"]:
             #todo: handle bgp rib collection
+            cmd_timer = 1200  # set the BGP RIB command timeout to 20 minutes
             continue
         # handle global and vrf specific IPv4 route commands
         if cmd_group == "routes_v4":
+            cmd_timer = 1200  # set the RIB command timeout to 20 minutes
+
             cmd_list = []
             for scope, cmds in cmd_dict['routes_v4'].items():
                 cmd_list.extend(cmds)


### PR DESCRIPTION
This PR:
 - provides a list of common show commands for Cisco IOS, IOS-XR and NXOS, Arista EOS, Juniper JunOS, Checkpoint and A10
 - adds support for show data collection for NXOS and IOSXR.
    - the structure for collecting routing table and BGP RIBs is strict and the user must follow the pattern in the include `show_commands.yml` file

Future PRs will add support for other platforms.