### PR TITLE
Extend show command collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ In the first three lines of this command, we are passing in username and passwor
 
 The third argument to the `snapshot_network.sh` script is optional and specifies where the output of the collector should be stored. The default value is the current working directory. 
 
-The snapshots are given a name based on collection time, such as `20211123_19:58:34`. Collected snapshots are uploaded to Batfish Enterprise but also left on local drive in the collection directory under a folder with the snapshot name. The logs will be under the folder `logs/20211123_19:58:34` in the collection directory. 
+The snapshots are given a name based on collection time, such as `20211123_19:58:34`. Collected snapshots are uploaded to Batfish but also left on local drive in the collection directory under a folder with the snapshot name. The logs will be under the folder `logs/20211123_19:58:34` in the collection directory. 
+
+####Note: The script also collects some standard show command output. This data is useable natively with Batfish Enterprise, but not with Batfish. Show data collection can take a long time, so if you do not want or need that data, remove the appropriate lines from the bash script.
 
 ## When using Batfish Enterprise
 

--- a/config_collector.py
+++ b/config_collector.py
@@ -316,7 +316,7 @@ def main(inventory: Dict, max_threads: int, username: str, password: str, snapsh
         device_os = AnsibleOsToNetmikoOs.get(grp_data['vars'].get('ansible_network_os'), None)
         if device_os is None:
             # todo: setup global logger to log this message to, for now print will get it into the bash script logs
-            print(f"Unsupported operating system {device_os}, skipping...")
+            print(f"Unsupported Ansible OS {grp_data['vars'].get('ansible_network_os')}, skipping...")
             continue
 
         for device_name, device_vars in grp_data.get('hosts').items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ future==0.18.2
 grpcio==1.35.0
 idna==3.3
 netconan==0.12.3
--e git+https://github.com/ktbyers/netmiko.git@6e40610a7daea87129ff490a9131cf7d3b794dd5#egg=netmiko
+netmiko==4.0.0
 ntc-templates==3.0.0
 numpy==1.21.4
 ordered-set==4.0.2

--- a/show_commands.yml
+++ b/show_commands.yml
@@ -122,11 +122,13 @@ all:
         - show route all
     bgp_v4:
       global:
-        - show route bgp detailed
-        - show bgp peers detailed
+        rib:
+          - show route bgp
+        neighbors:
+          - show bgp peers detailed
   a10:
     topology:
-      - show lldp neighbors detail
+      - show lldp neighbors
     version:
       - show version
     interface:
@@ -136,6 +138,7 @@ all:
     slb:
       - show slb virtual-server all-partitions
       - show slb virtual-server bind
+      - show slb virtual-server config all-partitions
     routes_v4:
       global:
         - show ip route database
@@ -143,9 +146,11 @@ all:
         - show ip route acos
     bgp_v4:
       global:
-        - show ip bgp summary
-        - show ip bgp neigbhors
-        - show ip bgp
+        neighbors:
+          - show ip bgp summary
+          - show ip bgp neighbors
+        rib:
+          - show ip bgp
 #    partition:   # this command requires parsing the partition output and is not currently handled
 #      slb:
 #        - show slb virtual-server bind

--- a/show_data_collector.py
+++ b/show_data_collector.py
@@ -435,7 +435,7 @@ def main(inventory: Dict, max_threads: int, username: str, password: str, snapsh
 
         if device_os is None:
             # todo: setup global logger to log this message to, for now print will get it into the bash script logs
-            print(f"Unsupported operating system {grp_data['vars'].get('ansible_network_os')}, skipping...")
+            print(f"Unsupported Ansible OS {grp_data['vars'].get('ansible_network_os')}, skipping...")
             continue
 
         op_func = OS_SHOW_COLLECTOR_FUNCTION.get(device_os)

--- a/show_data_collector.py
+++ b/show_data_collector.py
@@ -12,7 +12,6 @@ from collection_helper import (get_inventory, write_output_to_file, custom_logge
                                CollectionStatus, AnsibleOsToNetmikoOs, get_show_commands, parse_genie)
 
 
-
 def get_show_data(device_session: dict, device_name: str, output_path: str, cmd_dict: dict, logger) -> Dict:
     """
     Show command collector for all operating systems
@@ -393,6 +392,7 @@ def get_xr_data(device_session: dict, device_name: str, output_path: str, cmd_di
 
 
 OS_SHOW_COLLECTOR_FUNCTION = {
+    "cisco_ios": get_show_data,
     "cisco_nxos": get_nxos_data,
     "cisco_xr": get_xr_data,
     "arista_eos": get_show_data,

--- a/show_data_collector.py
+++ b/show_data_collector.py
@@ -433,7 +433,7 @@ def main(inventory: Dict, max_threads: int, username: str, password: str, snapsh
 
         if device_os is None:
             # todo: setup global logger to log this message to, for now print will get it into the bash script logs
-            print(f"Unsupported operating system {device_os}, skipping...")
+            print(f"Unsupported operating system {grp_data['vars'].get('ansible_network_os')}, skipping...")
             continue
 
         op_func = OS_SHOW_COLLECTOR_FUNCTION.get(device_os)

--- a/show_data_collector.py
+++ b/show_data_collector.py
@@ -407,12 +407,14 @@ def get_xr_data(device_session: dict, device_name: str, output_path: str, cmd_di
 
 
 OS_SHOW_COLLECTOR_FUNCTION = {
+    "a10": get_show_data,
+    "arista_eos": get_show_data,
+    "checkpoint_gaia": get_show_data,
+    "cisco_asa": get_show_data,
     "cisco_ios": get_show_data,
     "cisco_nxos": get_nxos_data,
     "cisco_xr": get_xr_data,
-    "arista_eos": get_show_data,
-    "checkpoint_gaia": get_show_data,
-    "a10": get_show_data
+    "juniper_junos": get_show_data
 }
 
 

--- a/snapshot_network.sh
+++ b/snapshot_network.sh
@@ -50,6 +50,15 @@ python ${SCRIPT_DIR}/config_collector.py \
 #grep -rle '^# Exported by' ${SNAPSHOT_DIR} | xargs sed -i -E 's/^(# Exported by [^ ]+ on ).*$/\1REMOVED/g'
 
 
+echo "Collecting show commands from devices"
+python ${SCRIPT_DIR}/show_data_collector.py \
+    --inventory ${INVENTORY} \
+    --collection-dir ${COLLECTION_DIR} \
+    --snapshot-name ${SNAPSHOT_NAME} \
+    --command-file ${SCRIPT_DIR}/show_commands.yml \
+    --max-threads 60
+
+
 BF_NETWORK=${BF_NETWORK:="MY_NETWORK"}
 echo "Uploading snapshot ${SNAPSHOT_NAME} to network ${BF_NETWORK}"
 python ${SCRIPT_DIR}/bfe_upload_snapshot.py \


### PR DESCRIPTION
- Created a generic show data collection function that can be used if per BGP neighbor RIBs are not required to be collected
- Updated code to enable collection for A10, Checkpoint, Cisco IOS, Arista EOS, Juniper JunOS
- Added show command collection to the bash script for BF snapshot collection
- Updated README

After this PR is merged, we can get rid of the `rib_collector.py` code.